### PR TITLE
Handle sections with reviewers but no maintainers

### DIFF
--- a/src/CheckCodeOwnersMaintainers.py
+++ b/src/CheckCodeOwnersMaintainers.py
@@ -168,7 +168,8 @@ def GetOwners(File, Sections):
         else:
           Reviewers.append(Item.rsplit('<')[1].rsplit('>')[0])
     Maintainers = list(set(Maintainers))
-    Reviewers = list(set(Reviewers))
+    # If someone is a maintainer, then they can not also be a reviewer
+    Reviewers = list(set(Reviewers) - set(Maintainers))
     Maintainers.sort()
     Reviewers.sort()
     return Maintainers, Reviewers
@@ -205,6 +206,8 @@ if __name__ == '__main__':
           print (f"  Maintainers.txt: {Maintainers}")
           CodeOwnerMismatchCount += 1
       CodeOwnersReviewers = [x[1] for x in LookupReviewers.of (File)]
+      # If someone is a maintainer, then they can not also be a reviewer
+      CodeOwnersReviewers = list(set(CodeOwnersReviewers) - set(CodeOwnersMaintainers))
       CodeOwnersReviewers.sort()
       if CodeOwnersReviewers != Reviewers:
           print (f"Reviewer mismatch for File: {File}")

--- a/src/GetMaintainer.py
+++ b/src/GetMaintainer.py
@@ -108,12 +108,16 @@ def get_maintainers(path, sections, level=0):
         if tmp_lists:
             lists += tmp_lists
 
-    if not maintainers:
+    MaintainersFound = False
+    for item in maintainers:
+        if item.strip().startswith('M:'):
+            MaintainersFound = True
+    if not MaintainersFound:
         # If no match found, look for match for (nonexistent) file
         # REPO.working_dir/<default>
         # print('"%s": no maintainers found, looking for default' % path)
         if level == 0:
-            maintainers = get_maintainers('<default>', sections, level=level + 1)
+            maintainers += get_maintainers('<default>', sections, level=level + 1)
         else:
             print("No <default> maintainers set for project.")
         if not maintainers:


### PR DESCRIPTION
If a section only has reviewers and no maintainers, then still use <default> maintainers.

If the same developers is listed as both a maintainer and a reviewer, then treat the developer as a maintainer.