### PR TITLE
Update GetMaintainer to return maintainers, reviewers, lists

### DIFF
--- a/src/CheckCodeOwnersMaintainers.py
+++ b/src/CheckCodeOwnersMaintainers.py
@@ -151,22 +151,19 @@ class CheckCodeOwnersMaintainers (object):
                       )
 
 def GetOwners(File, Sections):
-    List = GetMaintainer.get_maintainers(File, Sections)
-    if List is None:
-        return [], []
+    MaintainerList, ReviewerList, _ = GetMaintainer.get_maintainers(File, Sections)
     Maintainers = []
     Reviewers = []
-    for Item in List:
-      if Item.startswith('M:'):
-        if '[' in Item:
-          Maintainers.append('@' + Item.rsplit('[')[1].rsplit(']')[0])
-        else:
-          Maintainers.append(Item.rsplit('<')[1].rsplit('>')[0])
-      if Item.startswith('R:'):
-        if '[' in Item:
-          Reviewers.append('@' + Item.rsplit('[')[1].rsplit(']')[0])
-        else:
-          Reviewers.append(Item.rsplit('<')[1].rsplit('>')[0])
+    for Item in MaintainerList:
+      if '[' in Item:
+        Maintainers.append('@' + Item.rsplit('[')[1].rsplit(']')[0])
+      else:
+        Maintainers.append(Item.rsplit('<')[1].rsplit('>')[0])
+    for Item in ReviewerList:
+      if '[' in Item:
+        Reviewers.append('@' + Item.rsplit('[')[1].rsplit(']')[0])
+      else:
+        Reviewers.append(Item.rsplit('<')[1].rsplit('>')[0])
     Maintainers = list(set(Maintainers))
     # If someone is a maintainer, then they can not also be a reviewer
     Reviewers = list(set(Reviewers) - set(Maintainers))

--- a/src/GetMaintainer.py
+++ b/src/GetMaintainer.py
@@ -6,11 +6,13 @@
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
+from __future__ import print_function
 from collections import defaultdict
 from collections import OrderedDict
 import argparse
 import os
 import re
+#import SetupGit
 
 EXPRESSIONS = {
     'exclude':    re.compile(r'^X:\s*(?P<exclude>.*?)\r*$'),
@@ -74,6 +76,7 @@ def get_section_maintainers(path, section):
     """Returns a list with email addresses to any M: and R: entries
        matching the provided path in the provided section."""
     maintainers = []
+    reviewers = []
     lists = []
     nowarn_status = ['Supported', 'Maintained']
 
@@ -81,12 +84,18 @@ def get_section_maintainers(path, section):
         for status in section['status']:
             if status not in nowarn_status:
                 print('WARNING: Maintained status for "%s" is \'%s\'!' % (path, status))
-        for address in section['maintainer'], section['reviewer']:
+        for address in section['maintainer']:
             # Convert to list if necessary
             if isinstance(address, list):
                 maintainers += address
             else:
-                lists += [address]
+                maintainers += [address]
+        for address in section['reviewer']:
+            # Convert to list if necessary
+            if isinstance(address, list):
+                reviewers += address
+            else:
+                reviewers += [address]
         for address in section['list']:
             # Convert to list if necessary
             if isinstance(address, list):
@@ -94,36 +103,34 @@ def get_section_maintainers(path, section):
             else:
                 lists += [address]
 
-    return maintainers, lists
+    return maintainers, reviewers, lists
 
 def get_maintainers(path, sections, level=0):
     """For 'path', iterates over all sections, returning maintainers
        for matching ones."""
     maintainers = []
+    reviewers = []
     lists = []
     for section in sections:
-        tmp_maint, tmp_lists = get_section_maintainers(path, section)
-        if tmp_maint:
-            maintainers += tmp_maint
-        if tmp_lists:
-            lists += tmp_lists
+        tmp_maint, tmp_review, tmp_lists = get_section_maintainers(path, section)
+        maintainers += tmp_maint
+        reviewers += tmp_review
+        lists += tmp_lists
 
-    MaintainersFound = False
-    for item in maintainers:
-        if item.strip().startswith('M:'):
-            MaintainersFound = True
-    if not MaintainersFound:
+    if not maintainers:
         # If no match found, look for match for (nonexistent) file
         # REPO.working_dir/<default>
         # print('"%s": no maintainers found, looking for default' % path)
         if level == 0:
-            maintainers += get_maintainers('<default>', sections, level=level + 1)
+            maintainers, tmp_review, tmp_lists = get_maintainers('<default>', sections, level=level + 1)
+            reviewers += tmp_review
+            lists += tmp_lists
         else:
             print("No <default> maintainers set for project.")
         if not maintainers:
             return None
 
-    return maintainers + lists
+    return maintainers, reviewers, lists
 
 def parse_maintainers_line(line):
     """Parse one line of Maintainers.txt, returning any match group and its key."""
@@ -143,10 +150,7 @@ def parse_maintainers_file(filename):
         while line:
             key, value = parse_maintainers_line(line)
             if key and value:
-                if key in ['maintainer', 'reviewer']:
-                    section[key].append(line.strip())
-                else:
-                    section[key].append(value)
+                section[key].append(value)
 
             line = text.readline()
             # If end of section (end of file, or non-tag line encountered)...
@@ -176,7 +180,7 @@ if __name__ == '__main__':
                         required=False)
     ARGS = PARSER.parse_args()
 
-    REPO = SetupGit.locate_repo()
+#    REPO = SetupGit.locate_repo()
 
     CONFIG_FILE = os.path.join(REPO.working_dir, 'Maintainers.txt')
 
@@ -187,15 +191,16 @@ if __name__ == '__main__':
     else:
         FILES = get_modified_files(REPO, ARGS)
 
-    ADDRESSES = []
-
+    # Accumulate a sorted list of addresses
+    ADDRESSES = set([])
     for file in FILES:
         print(file)
-        addresslist = get_maintainers(file, SECTIONS)
-        if addresslist:
-            ADDRESSES += addresslist
+        maintainers, reviewers, lists = get_maintainers(file, SECTIONS)
+        ADDRESSES |= set(maintainers + reviewers + lists)
+    ADDRESSES = list(ADDRESSES)
+    ADDRESSES.sort()
 
-    for address in list(OrderedDict.fromkeys(ADDRESSES)):
+    for address in ADDRESSES:
         if '<' in address and '>' in address:
             address = address.split('>', 1)[0] + '>'
         print('  %s' % address)


### PR DESCRIPTION
This simplifies the logic in GetOwners() by removing the need to look for M: or R: in the items returned and aligns GetMaintainer with edk2/BaseTools/Scripts/GetMaintainer.py